### PR TITLE
Fix Nginx documentation

### DIFF
--- a/doc/nginx/Readme.md
+++ b/doc/nginx/Readme.md
@@ -46,11 +46,11 @@ Example config:
         # and make sure to comment these out in "dev" environment.
         include ez_params.d/ez_prod_rewrite_params;
 
-        # Access to repository images in single server setup
-        include ez_params.d/ez_rewrite_params;
-
         # Legacy rewrite rules
         include ez_params.d/ez_legacy_rewrite_params;
+
+        # Access to repository images in single server setup
+        include ez_params.d/ez_rewrite_params;
 
         # upload max size
         client_max_body_size 48m;


### PR DESCRIPTION
Hi there,
The last directive from `ez_params.d/ez_rewrite_params` is a catch all so the legacy rules from `ez_params.d/ez_legacy_rewrite_params` were not played.
Have a nice day and thanks for this repository.